### PR TITLE
Added Nearby Tracker Open

### DIFF
--- a/Manager/Sources/RDMUICManager/BuildController.swift
+++ b/Manager/Sources/RDMUICManager/BuildController.swift
@@ -197,7 +197,7 @@ class BuildController {
             "startupLocationLon=\(device.startupLocationLon)", "encounterMaxWait=\(device.encounterMaxWait)",
             "encounterDelay=\(device.encounterDelay)", "fastIV=\(device.fastIV)", "ultraIV=\(device.ultraIV)",
             "deployEggs=\(device.deployEggs)", "token=\(device.token)", "ultraQuests=\(device.ultraQuests)",
-            "attachScreenshots=\(device.attachScreenshots)"
+            "attachScreenshots=\(device.attachScreenshots)", "nearbyTracker=\(device.nearbyTracker)"
         )
 
         var contains = true
@@ -273,6 +273,15 @@ class BuildController {
                         }
                         if string!.contains(string: "[STATUS] IV") {
                             self.setStatus(uuid: device.uuid, status: "Running: IV")
+                        }
+                        if string!.contains(string: "[STATUS] NTM Pokemon") {
+                            self.setStatus(uuid: device.uuid, status: "Running: NTM Pokemon")
+                        }
+                        if string!.contains(string: "[STATUS] NTM Raid") {
+                            self.setStatus(uuid: device.uuid, status: "Running: NTM Raid")
+                        }
+                        if string!.contains(string: "[STATUS] NTM IV") {
+                            self.setStatus(uuid: device.uuid, status: "Running: NTM IV")
                         }
 
                         fullLog.uic(message: string!, all: true)

--- a/Manager/Sources/RDMUICManager/CLI.swift
+++ b/Manager/Sources/RDMUICManager/CLI.swift
@@ -168,6 +168,7 @@ class CLI {
             Ultra Quests: \(device.ultraQuests.toBool())
             Enabled: \(device.enabled.toBool())
             AttachScreenshots: \(device.attachScreenshots.toBool())
+            Nearby Tracker: \(device.nearbyTracker.toBool())
             """
 
             print(row + "\n")
@@ -315,6 +316,11 @@ class CLI {
         let attachScreenshots = askBool("Attach Screenshots (empty = \(defaultDevice.attachScreenshots.toBool()))")
         if attachScreenshots != nil {
             defaultDevice.attachScreenshots = attachScreenshots!.toInt()
+        }
+
+        let nearbyTracker = askBool("Nearby Tracker (empty = \(defaultDevice.nearbyTracker.toBool()))")
+        if nearbyTracker != nil {
+            defaultDevice.nearbyTracker = nearbyTracker!.toInt()
         }
 
         do {
@@ -473,6 +479,11 @@ class CLI {
             attachScreenshots = defaultDevice.attachScreenshots
         }
 
+        var nearbyTracker = askBool("Nearby Tracker (empty = \(defaultDevice.nearbyTracker.toBool()))")?.toInt()
+        if nearbyTracker == nil {
+            nearbyTracker = defaultDevice.nearbyTracker
+        }
+
         device.uuid = uuid
         device.name = name
         device.backendURL = backendURL
@@ -502,6 +513,7 @@ class CLI {
         device.ultraQuests = ultraQuests!
         device.enabled = enabled!
         device.attachScreenshots = attachScreenshots!
+        device.nearbyTracker = nearbyTracker!
 
         do {
             try device.create()
@@ -672,6 +684,11 @@ class CLI {
         let attachScreenshots = askBool("Attach Screenshots (empty = \(device.attachScreenshots.toBool()))")
         if attachScreenshots != nil {
             device.attachScreenshots = attachScreenshots!.toInt()
+        }
+
+        let nearbyTracker = askBool("Nearby Tracker (empty = \(device.nearbyTracker.toBool()))")
+        if nearbyTracker != nil {
+            device.nearbyTracker = nearbyTracker!.toInt()
         }
 
         do {

--- a/Manager/Sources/RDMUICManager/Device.swift
+++ b/Manager/Sources/RDMUICManager/Device.swift
@@ -53,6 +53,7 @@ class Device: SQLiteStORM, Equatable, Hashable {
     var ultraQuests: Int
     var enabled: Int
     var attachScreenshots: Int
+    var nearbyTracker: Int
 
     override init() {
         self.uuid = ""
@@ -84,6 +85,7 @@ class Device: SQLiteStORM, Equatable, Hashable {
 		self.ultraQuests = 0
         self.enabled = 1
         self.attachScreenshots = 0
+        self.nearbyTracker = 0
         super.init()
     }
 
@@ -92,7 +94,7 @@ class Device: SQLiteStORM, Equatable, Hashable {
          targetMaxDistance: Double, itemFullCount: Int, questFullCount: Int, itemsPerStop: Int, minDelayLogout: Double,
          maxNoQuestCount: Int, maxFailedCount: Int, maxEmptyGMO: Int, startupLocationLat: Double,
          startupLocationLon: Double, encounterMaxWait: Int, encounterDelay: Double, fastIV: Int, ultraIV: Int,
-         deployEggs: Int, token: String, ultraQuests: Int, enabled: Int, attachScreenshots: Int) {
+         deployEggs: Int, token: String, ultraQuests: Int, enabled: Int, attachScreenshots: Int, nearbyTracker: Int) {
         self.uuid = uuid
         self.name = name
         self.backendURL = backendURL
@@ -122,6 +124,7 @@ class Device: SQLiteStORM, Equatable, Hashable {
 		self.ultraQuests = ultraQuests
         self.enabled = enabled
         self.attachScreenshots = attachScreenshots
+        self.nearbyTracker = nearbyTracker
         super.init()
     }
 
@@ -156,9 +159,10 @@ class Device: SQLiteStORM, Equatable, Hashable {
         ultraIV = this.data["ultraIV"] as? Int ?? 0
         deployEggs = this.data["deployEggs"] as? Int ?? 0
         token = this.data["token"] as? String ?? ""
-		ultraQuests = this.data["ultraQuests"] as? Int ?? 0
+        ultraQuests = this.data["ultraQuests"] as? Int ?? 0
         enabled = this.data["enabled"] as? Int ?? 1
         attachScreenshots = this.data["attachScreenshots"] as? Int ?? 0
+        nearbyTracker = this.data["nearbyTracker"] as? Int ?? 0
     }
 
     static func getAll() -> [Device] {
@@ -213,6 +217,7 @@ class Device: SQLiteStORM, Equatable, Hashable {
 		var hasUltraQuests = false
         var hasEnabled = false
         var hasAttachScreenshots = false
+        var hasNearbyTracker = false
 
         let rows = try sqlRows("PRAGMA table_info(\(table()))", params: [String]())
         for row in rows {
@@ -235,6 +240,8 @@ class Device: SQLiteStORM, Equatable, Hashable {
                 hasEnabled = true
             } else if name == "attachScreenshots" {
                 hasAttachScreenshots = true
+            } else if name == "nearbyTracker" {
+                hasNearbyTracker = true
             }
         }
 
@@ -264,6 +271,9 @@ class Device: SQLiteStORM, Equatable, Hashable {
         }
         if !hasAttachScreenshots {
             try sqlExec("ALTER TABLE \(table()) ADD COLUMN attachScreenshots INTEGER DEFAULT 0")
+        }
+        if !hasNearbyTracker {
+            try sqlExec("ALTER TABLE \(table()) ADD COLUMN nearbyTracker INTEGER DEFAULT 0")
         }
     }
 

--- a/RealDeviceMap-UIControl.xcodeproj/xcshareddata/xcschemes/RealDeviceMap-UIControl.xcscheme
+++ b/RealDeviceMap-UIControl.xcodeproj/xcshareddata/xcschemes/RealDeviceMap-UIControl.xcscheme
@@ -208,6 +208,11 @@
             value = "$(attachScreenshots)"
             isEnabled = "YES">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "nearbyTracker"
+            value = "$(nearbyTracker)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
       </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>

--- a/RealDeviceMap-UIControl/Config.swift
+++ b/RealDeviceMap-UIControl/Config.swift
@@ -39,6 +39,7 @@ class Config {
     var ultraQuests: Bool
     var enabled: Bool
     var attachScreenshots: Bool
+    var nearbyTracker: Bool
 
     init() {
 
@@ -74,6 +75,7 @@ class Config {
         ultraQuests = enviroment["ultraQuests"]?.toBool() ?? false
         enabled = enviroment["enabled"]?.toBool() ?? true
         attachScreenshots = enviroment["attachScreenshots"]?.toBool() ?? false
+        nearbyTracker = enviroment["nearbyTracker"]?.toBool() ?? false
     }
 
 }

--- a/RealDeviceMap-UIControl/DeviceConfig/DeviceConfigProtocol.swift
+++ b/RealDeviceMap-UIControl/DeviceConfig/DeviceConfigProtocol.swift
@@ -13,6 +13,10 @@ protocol DeviceConfigProtocol {
 
     /** Green pixel in green button of startup popup. */
     var startup: DeviceCoordinate { get }
+    /** Nearby Tracker. */
+    var nearby: DeviceCoordinate { get }
+    /** Nearby Tracker Pixel. */
+    var nearbypixel: DeviceCoordinate { get }
 
     // Handling Multiple startup prompts
     /* White Pixel (on 3 line prompt) or Greenish-Blue Pixel (on 2 line prompt) bottom right corner of 2line popup */

--- a/RealDeviceMap-UIControl/DeviceConfig/DeviceIPhoneNormal.swift
+++ b/RealDeviceMap-UIControl/DeviceConfig/DeviceIPhoneNormal.swift
@@ -15,10 +15,10 @@ class DeviceIPhoneNormal: DeviceRatio1775 {
         return DeviceCoordinate(x: 325, y: 960, tapScaler: tapScaler)
     }
     override var nearby: DeviceCoordinate {
-        return DeviceCoordinate(x: 645, y: 1215)
+        return DeviceCoordinate(x: 645, y: 1215, tapScaler: tapScaler)
     }
     override var nearbypixel: DeviceCoordinate {
-        return DeviceCoordinate(x: 146, y: 310)
+        return DeviceCoordinate(x: 146, y: 310, tapScaler: tapScaler)
     }
     override var startupNewButton: DeviceCoordinate {
         return DeviceCoordinate(x: 475, y: 960, tapScaler: tapScaler)

--- a/RealDeviceMap-UIControl/DeviceConfig/DeviceIPhoneNormal.swift
+++ b/RealDeviceMap-UIControl/DeviceConfig/DeviceIPhoneNormal.swift
@@ -14,6 +14,12 @@ class DeviceIPhoneNormal: DeviceRatio1775 {
     override var startup: DeviceCoordinate {
         return DeviceCoordinate(x: 325, y: 960, tapScaler: tapScaler)
     }
+    override var nearby: DeviceCoordinate {
+        return DeviceCoordinate(x: 645, y: 1215)
+    }
+    override var nearbypixel: DeviceCoordinate {
+        return DeviceCoordinate(x: 146, y: 310)
+    }
     override var startupNewButton: DeviceCoordinate {
         return DeviceCoordinate(x: 475, y: 960, tapScaler: tapScaler)
     }

--- a/RealDeviceMap-UIControl/DeviceConfig/DeviceIPhoneNormal.swift
+++ b/RealDeviceMap-UIControl/DeviceConfig/DeviceIPhoneNormal.swift
@@ -4,6 +4,7 @@
 //
 //  Created by Florian Kostenzer on 19.11.18.
 //
+//  IPHONE 6/6S/7/8
 
 import Foundation
 

--- a/RealDeviceMap-UIControl/DeviceConfig/DeviceIPhoneNormal.swift
+++ b/RealDeviceMap-UIControl/DeviceConfig/DeviceIPhoneNormal.swift
@@ -4,7 +4,6 @@
 //
 //  Created by Florian Kostenzer on 19.11.18.
 //
-//  IPHONE 6/6S/7/8
 
 import Foundation
 

--- a/RealDeviceMap-UIControl/DeviceConfig/DeviceRatio1333.swift
+++ b/RealDeviceMap-UIControl/DeviceConfig/DeviceRatio1333.swift
@@ -29,6 +29,12 @@ class DeviceRatio1333: DeviceConfigProtocol {
     var startup: DeviceCoordinate {
         return DeviceCoordinate(x: 728, y: 1542, scaler: scaler) //was 1234
     }
+    var nearby: DeviceCoordinate {
+        return DeviceCoordinate(x: 0, y: 0, scaler: scaler) // Need Screenshot Cords
+    }
+    var nearbypixel: DeviceCoordinate {
+        return DeviceCoordinate(x: 1387, y: 1873, scaler: scaler)
+    }
     var startupLoggedOut: DeviceCoordinate {
         return DeviceCoordinate(x: 807, y: 177, scaler: scaler)
     }

--- a/RealDeviceMap-UIControl/DeviceConfig/DeviceRatio1775.swift
+++ b/RealDeviceMap-UIControl/DeviceConfig/DeviceRatio1775.swift
@@ -4,6 +4,7 @@
 //
 //  Created by Florian Kostenzer on 18.11.18.
 //
+//  IPHONE 5S/SE
 
 import Foundation
 import XCTest

--- a/RealDeviceMap-UIControl/DeviceConfig/DeviceRatio1775.swift
+++ b/RealDeviceMap-UIControl/DeviceConfig/DeviceRatio1775.swift
@@ -33,6 +33,12 @@ class DeviceRatio1775: DeviceConfigProtocol {
     var startup: DeviceCoordinate {
         return DeviceCoordinate(x: 280, y: 800, scaler: scaler)
     }
+    var nearby: DeviceCoordinate {
+        return DeviceCoordinate(x: 550, y: 1040, scaler: scaler)
+    }
+    var nearbypixel: DeviceCoordinate {
+        return DeviceCoordinate(x: 125, y: 265, scaler: scaler) 
+    }
     var startupLoggedOut: DeviceCoordinate {
         return DeviceCoordinate(x: 320, y: 175, scaler: scaler)
     }

--- a/RealDeviceMap-UIControl/DeviceConfig/DeviceRatio1775.swift
+++ b/RealDeviceMap-UIControl/DeviceConfig/DeviceRatio1775.swift
@@ -4,7 +4,6 @@
 //
 //  Created by Florian Kostenzer on 18.11.18.
 //
-//  IPHONE 5S/SE
 //  swiftlint:disable type_body_length file_length
 //
 

--- a/RealDeviceMap-UIControl/DeviceConfig/DeviceRatio1775.swift
+++ b/RealDeviceMap-UIControl/DeviceConfig/DeviceRatio1775.swift
@@ -37,7 +37,7 @@ class DeviceRatio1775: DeviceConfigProtocol {
         return DeviceCoordinate(x: 550, y: 1040, scaler: scaler)
     }
     var nearbypixel: DeviceCoordinate {
-        return DeviceCoordinate(x: 125, y: 265, scaler: scaler) 
+        return DeviceCoordinate(x: 125, y: 265, scaler: scaler)
     }
     var startupLoggedOut: DeviceCoordinate {
         return DeviceCoordinate(x: 320, y: 175, scaler: scaler)

--- a/RealDeviceMap-UIControl/Misc.swift
+++ b/RealDeviceMap-UIControl/Misc.swift
@@ -1311,6 +1311,19 @@ extension XCTestCase {
         return false
     }
 
+    func checkNearbyPixel(screenshot: XCUIScreenshot?=nil) -> Bool {
+        self.clickPassengerWarning()
+        let screenshotComp = screenshot ?? XCUIScreen.main.screenshot()
+        if screenshotComp.rgbAtLocation(
+            pos: deviceConfig.nearbypixel,
+            min: (red: 0.25, green: 0.40, blue: 0.41),
+            max: (red: 0.27, green: 0.42, blue: 0.43)) {
+            return true
+        } else {
+            return false
+        }
+    }
+
 }
 
 extension String {

--- a/RealDeviceMap-UIControl/Misc.swift
+++ b/RealDeviceMap-UIControl/Misc.swift
@@ -1312,7 +1312,6 @@ extension XCTestCase {
     }
 
     func checkNearbyPixel(screenshot: XCUIScreenshot?=nil) -> Bool {
-        self.clickPassengerWarning()
         let screenshotComp = screenshot ?? XCUIScreen.main.screenshot()
         if screenshotComp.rgbAtLocation(
             pos: deviceConfig.nearbypixel,

--- a/RealDeviceMap-UIControl/RealDeviceMap_UIControlUITests.swift
+++ b/RealDeviceMap-UIControl/RealDeviceMap_UIControlUITests.swift
@@ -40,6 +40,7 @@ class RealDeviceMap_UIControlUITests: XCTestCase {
     var encounterDelay = 1.0
     var server = Server()
     var hasWarning = false
+    var hasnearby = false
 
     var level: Int = 0
     var systemAlertMonitorToken: NSObjectProtocol?
@@ -1123,6 +1124,20 @@ class RealDeviceMap_UIControlUITests: XCTestCase {
                         deviceConfig.startup.toXCUICoordinate(app: app).tap()
                         app.swipeDown()
                     }
+
+                    if self.config.nearbyTracker {
+                        Log.info("STARTUP nearbyTracker \(self.config.nearbyTracker)")
+                        self.hasnearby = self.checkNearbyPixel()
+                        sleep(2)
+                        self.hasnearby = self.checkNearbyPixel()
+                        Log.info("STARTUP hasnearby \(self.hasnearby)")
+                        if !self.hasnearby {
+                            deviceConfig.nearby.toXCUICoordinate(app: app).tap()
+                            sleep(1)
+                            Log.info("STARTUP Nearby Tap")
+                        }
+                    }
+
                     sleep(1 * config.delayMultiplier)
 
                     isStartupCompleted = true
@@ -1202,7 +1217,11 @@ class RealDeviceMap_UIControlUITests: XCTestCase {
                         if let data = result!["data"] as? [String: Any], let action = data["action"] as? String {
                             self.action = action
                             if action == "scan_pokemon" {
-                                print("[STATUS] Pokemon")
+                                if self.config.nearbyTracker {
+                                    print("[STATUS] NTM Pokemon")
+                                } else {
+                                    print("[STATUS] Pokemon")
+                                }
                                 if self.hasWarning && self.config.enableAccountManager {
                                     Log.info("Account has a warning and tried to scan for Pokemon. Logging out!")
                                     self.lock.lock()
@@ -1264,9 +1283,24 @@ class RealDeviceMap_UIControlUITests: XCTestCase {
                                     }
                                     self.lock.unlock()
                                 }
+                                if self.config.nearbyTracker {
+                                    self.hasnearby = self.checkNearbyPixel()
+                                    sleep(2)
+                                    self.hasnearby = self.checkNearbyPixel()
+                                    Log.info("POKEMON hasnearby \(self.hasnearby)")
+                                    if !self.hasnearby {
+                                        self.deviceConfig.nearby.toXCUICoordinate(app: self.app).tap()
+                                        sleep(1)
+                                        Log.info("POKEMON Nearby Tap")
+                                    }
+                                }
 
                             } else if action == "scan_raid" {
-                                print("[STATUS] Raid")
+                                if self.config.nearbyTracker {
+                                    print("[STATUS] NTM Raid")
+                                } else {
+                                    print("[STATUS] Raid")
+                                }
                                 if self.hasWarning && self.firstWarningDate != nil &&
                                    Int(Date().timeIntervalSince(self.firstWarningDate!)) >=
                                      self.config.maxWarningTimeRaid && self.config.enableAccountManager {
@@ -1329,6 +1363,18 @@ class RealDeviceMap_UIControlUITests: XCTestCase {
                                     }
                                     self.lock.unlock()
                                 }
+                                if self.config.nearbyTracker {
+                                    self.hasnearby = self.checkNearbyPixel()
+                                    sleep(2)
+                                    self.hasnearby = self.checkNearbyPixel()
+                                    Log.info("RAID hasnearby \(self.hasnearby)")
+                                    if !self.hasnearby {
+                                        self.deviceConfig.nearby.toXCUICoordinate(app: self.app).tap()
+                                        sleep(1)
+                                        Log.info("RAID Nearby Tap")
+                                    }
+                                }
+
                             } else if action == "scan_quest" {
                                 print("[STATUS] Quest")
 
@@ -1553,7 +1599,11 @@ class RealDeviceMap_UIControlUITests: XCTestCase {
                                 self.shouldExit = true
                                 return
                             } else if action == "scan_iv" {
-                                print("[STATUS] IV")
+                                if self.config.nearbyTracker {
+                                    print("[STATUS] NTM IV")
+                                } else {
+                                    print("[STATUS] IV")
+                                }
                                 if self.hasWarning && self.firstWarningDate != nil &&
                                    Int(Date().timeIntervalSince(self.firstWarningDate!)) >=
                                      self.config.maxWarningTimeRaid && self.config.enableAccountManager {
@@ -1830,6 +1880,17 @@ class RealDeviceMap_UIControlUITests: XCTestCase {
 
                                     }
 
+                                }
+                                if self.config.nearbyTracker {
+                                    self.hasnearby = self.checkNearbyPixel()
+                                    sleep(2)
+                                    self.hasnearby = self.checkNearbyPixel()
+                                    Log.info("IV hasnearby \(self.hasnearby)")
+                                    if self.config.ultraIV && !self.hasnearby {
+                                        self.deviceConfig.nearby.toXCUICoordinate(app: self.app).tap()
+                                        sleep(1)
+                                        Log.info("IV Nearby Tap")
+                                    }
                                 }
 
                             } else {


### PR DESCRIPTION
Added Nearby Tracker Open

## Description
Added Nearby Tracker Open On Startup/ Pokemon Scanned/Raid Scanned And IV Scanned And Added Status Text For Manager For Each Mode, Also Added True/False Toggle In Manager, Does A Pixel Check To Make Sure The Tracker Is Open And Doesn't Over Tap.

## Motivation and Context
Several Others And I Have Noticed Improved Round Timers And Loading, Varies From Map To Map 
(Some People May Notice No Change)

## How Has This Been Tested?
Been Running It For Months, Recently Updated To Latest UIC So Decided To Make A PR Finally

## Screenshots (if appropriate):
Opens The Ingame Tracker

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
