### PR TITLE
Added Wilds Only Toggle

### DIFF
--- a/Manager/Sources/RDMUICManager/BuildController.swift
+++ b/Manager/Sources/RDMUICManager/BuildController.swift
@@ -197,7 +197,7 @@ class BuildController {
             "startupLocationLon=\(device.startupLocationLon)", "encounterMaxWait=\(device.encounterMaxWait)",
             "encounterDelay=\(device.encounterDelay)", "fastIV=\(device.fastIV)", "ultraIV=\(device.ultraIV)",
             "deployEggs=\(device.deployEggs)", "token=\(device.token)", "ultraQuests=\(device.ultraQuests)",
-            "attachScreenshots=\(device.attachScreenshots)"
+            "attachScreenshots=\(device.attachScreenshots)", "wildsOnly=\(device.wildsOnly)"
         )
 
         var contains = true
@@ -273,6 +273,9 @@ class BuildController {
                         }
                         if string!.contains(string: "[STATUS] IV") {
                             self.setStatus(uuid: device.uuid, status: "Running: IV")
+                        }
+                        if string!.contains(string: "[STATUS] WO Pokemon") {
+                            self.setStatus(uuid: device.uuid, status: "Running: WO Pokemon")
                         }
 
                         fullLog.uic(message: string!, all: true)

--- a/Manager/Sources/RDMUICManager/CLI.swift
+++ b/Manager/Sources/RDMUICManager/CLI.swift
@@ -168,6 +168,7 @@ class CLI {
             Ultra Quests: \(device.ultraQuests.toBool())
             Enabled: \(device.enabled.toBool())
             AttachScreenshots: \(device.attachScreenshots.toBool())
+            Wilds Only: \(device.wildsOnly.toBool())
             """
 
             print(row + "\n")
@@ -315,6 +316,11 @@ class CLI {
         let attachScreenshots = askBool("Attach Screenshots (empty = \(defaultDevice.attachScreenshots.toBool()))")
         if attachScreenshots != nil {
             defaultDevice.attachScreenshots = attachScreenshots!.toInt()
+        }
+
+        let wildsOnly = askBool("Wilds Only (empty = \(defaultDevice.wildsOnly.toBool()))")
+        if wildsOnly != nil {
+            defaultDevice.wildsOnly = wildsOnly!.toInt()
         }
 
         do {
@@ -473,6 +479,11 @@ class CLI {
             attachScreenshots = defaultDevice.attachScreenshots
         }
 
+        var wildsOnly = askBool("Wilds Only (empty = \(defaultDevice.wildsOnly.toBool()))")?.toInt()
+        if wildsOnly == nil {
+            wildsOnly = defaultDevice.wildsOnly
+        }
+
         device.uuid = uuid
         device.name = name
         device.backendURL = backendURL
@@ -502,6 +513,7 @@ class CLI {
         device.ultraQuests = ultraQuests!
         device.enabled = enabled!
         device.attachScreenshots = attachScreenshots!
+        device.wildsOnly = wildsOnly!
 
         do {
             try device.create()
@@ -672,6 +684,11 @@ class CLI {
         let attachScreenshots = askBool("Attach Screenshots (empty = \(device.attachScreenshots.toBool()))")
         if attachScreenshots != nil {
             device.attachScreenshots = attachScreenshots!.toInt()
+        }
+
+        let wildsOnly = askBool("Wilds Only (empty = \(device.wildsOnly.toBool()))")
+        if wildsOnly != nil {
+            device.wildsOnly = wildsOnly!.toInt()
         }
 
         do {

--- a/Manager/Sources/RDMUICManager/Device.swift
+++ b/Manager/Sources/RDMUICManager/Device.swift
@@ -53,6 +53,7 @@ class Device: SQLiteStORM, Equatable, Hashable {
     var ultraQuests: Int
     var enabled: Int
     var attachScreenshots: Int
+    var wildsOnly: Int
 
     override init() {
         self.uuid = ""
@@ -84,6 +85,7 @@ class Device: SQLiteStORM, Equatable, Hashable {
 		self.ultraQuests = 0
         self.enabled = 1
         self.attachScreenshots = 0
+        self.wildsOnly = 0
         super.init()
     }
 
@@ -92,7 +94,7 @@ class Device: SQLiteStORM, Equatable, Hashable {
          targetMaxDistance: Double, itemFullCount: Int, questFullCount: Int, itemsPerStop: Int, minDelayLogout: Double,
          maxNoQuestCount: Int, maxFailedCount: Int, maxEmptyGMO: Int, startupLocationLat: Double,
          startupLocationLon: Double, encounterMaxWait: Int, encounterDelay: Double, fastIV: Int, ultraIV: Int,
-         deployEggs: Int, token: String, ultraQuests: Int, enabled: Int, attachScreenshots: Int) {
+         deployEggs: Int, token: String, ultraQuests: Int, enabled: Int, attachScreenshots: Int, wildsOnly: Int) {
         self.uuid = uuid
         self.name = name
         self.backendURL = backendURL
@@ -122,6 +124,7 @@ class Device: SQLiteStORM, Equatable, Hashable {
 		self.ultraQuests = ultraQuests
         self.enabled = enabled
         self.attachScreenshots = attachScreenshots
+        self.wildsOnly = wildsOnly
         super.init()
     }
 
@@ -159,6 +162,7 @@ class Device: SQLiteStORM, Equatable, Hashable {
 		ultraQuests = this.data["ultraQuests"] as? Int ?? 0
         enabled = this.data["enabled"] as? Int ?? 1
         attachScreenshots = this.data["attachScreenshots"] as? Int ?? 0
+        wildsOnly = this.data["wildsOnly"] as? Int ?? 0
     }
 
     static func getAll() -> [Device] {
@@ -213,6 +217,7 @@ class Device: SQLiteStORM, Equatable, Hashable {
 		var hasUltraQuests = false
         var hasEnabled = false
         var hasAttachScreenshots = false
+        var hasWildsOnly = false
 
         let rows = try sqlRows("PRAGMA table_info(\(table()))", params: [String]())
         for row in rows {
@@ -235,6 +240,8 @@ class Device: SQLiteStORM, Equatable, Hashable {
                 hasEnabled = true
             } else if name == "attachScreenshots" {
                 hasAttachScreenshots = true
+            } else if name == "wildsOnly" {
+                hasWildsOnly = true
             }
         }
 
@@ -264,6 +271,9 @@ class Device: SQLiteStORM, Equatable, Hashable {
         }
         if !hasAttachScreenshots {
             try sqlExec("ALTER TABLE \(table()) ADD COLUMN attachScreenshots INTEGER DEFAULT 0")
+        }
+        if !hasWildsOnly {
+            try sqlExec("ALTER TABLE \(table()) ADD COLUMN wildsOnly INTEGER DEFAULT 0")
         }
     }
 

--- a/RealDeviceMap-UIControl.xcodeproj/xcshareddata/xcschemes/RealDeviceMap-UIControl.xcscheme
+++ b/RealDeviceMap-UIControl.xcodeproj/xcshareddata/xcschemes/RealDeviceMap-UIControl.xcscheme
@@ -208,6 +208,11 @@
             value = "$(attachScreenshots)"
             isEnabled = "YES">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "wildsOnly"
+            value = "$(wildsOnly)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
       </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>

--- a/RealDeviceMap-UIControl/Config.swift
+++ b/RealDeviceMap-UIControl/Config.swift
@@ -39,6 +39,7 @@ class Config {
     var ultraQuests: Bool
     var enabled: Bool
     var attachScreenshots: Bool
+    var wildsOnly: Bool
 
     init() {
 
@@ -74,6 +75,7 @@ class Config {
         ultraQuests = enviroment["ultraQuests"]?.toBool() ?? false
         enabled = enviroment["enabled"]?.toBool() ?? true
         attachScreenshots = enviroment["attachScreenshots"]?.toBool() ?? false
+        wildsOnly = enviroment["wildsOnly"]?.toBool() ?? false
     }
 
 }

--- a/RealDeviceMap-UIControl/RealDeviceMap_UIControlUITests.swift
+++ b/RealDeviceMap-UIControl/RealDeviceMap_UIControlUITests.swift
@@ -926,37 +926,72 @@ class RealDeviceMap_UIControlUITests: XCTestCase {
                         self.emptyGmoCount = 0
 
                         if self.pokemonEncounterId != nil {
-                            if (nearby + wild) > 0 {
-                                if pokemonLat != nil && pokemonLon != nil &&
-                                   self.pokemonEncounterId == pokemonEncounterIdResult {
-                                    self.waitRequiresPokemon = false
-                                    let oldLocation = CLLocation(latitude: self.currentLocation!.lat,
-                                                                 longitude: self.currentLocation!.lon)
-                                    self.currentLocation = (pokemonLat!, pokemonLon!)
-                                    let newLocation = CLLocation(latitude: self.currentLocation!.lat,
-                                                                 longitude: self.currentLocation!.lon)
-                                    self.encounterDistance = newLocation.distance(from: oldLocation)
-                                    self.pokemonEncounterId = nil
-                                    if self.listScatterPokemon {
-                                        self.listScatterPokemon = false
-                                        self.scatterPokemon = data?["scatter_pokemon"]
-                                            as? [[String: Any]] ?? [[String: Any]]()
+                            if !self.config.wildsOnly {
+                                if (nearby + wild) > 0 {
+                                    if pokemonLat != nil && pokemonLon != nil &&
+                                       self.pokemonEncounterId == pokemonEncounterIdResult {
+                                        self.waitRequiresPokemon = false
+                                        let oldLocation = CLLocation(latitude: self.currentLocation!.lat,
+                                                                     longitude: self.currentLocation!.lon)
+                                        self.currentLocation = (pokemonLat!, pokemonLon!)
+                                        let newLocation = CLLocation(latitude: self.currentLocation!.lat,
+                                                                     longitude: self.currentLocation!.lon)
+                                        self.encounterDistance = newLocation.distance(from: oldLocation)
+                                        self.pokemonEncounterId = nil
+                                        if self.listScatterPokemon {
+                                            self.listScatterPokemon = false
+                                            self.scatterPokemon = data?["scatter_pokemon"]
+                                                as? [[String: Any]] ?? [[String: Any]]()
+                                        }
+                                        self.waitForData = false
+                                        toPrint = "[DEBUG] Got Data and found Nearby And Wild Pokemon"
+                                    } else {
+                                        toPrint = "[DEBUG] Got Data but didn't find Nearby And Wild Pokemon"
                                     }
-                                    self.waitForData = false
-                                    toPrint = "[DEBUG] Got Data and found Pokemon"
                                 } else {
-                                    toPrint = "[DEBUG] Got Data but didn't find Pokemon"
+                                    toPrint = "[DEBUG] Got Data without Nearby And Wild Pokemon"
                                 }
                             } else {
-                                toPrint = "[DEBUG] Got Data without Pokemon"
+                                if (wild) > 0 {
+                                    if pokemonLat != nil && pokemonLon != nil &&
+                                       self.pokemonEncounterId == pokemonEncounterIdResult {
+                                        self.waitRequiresPokemon = false
+                                        let oldLocation = CLLocation(latitude: self.currentLocation!.lat,
+                                                                     longitude: self.currentLocation!.lon)
+                                        self.currentLocation = (pokemonLat!, pokemonLon!)
+                                        let newLocation = CLLocation(latitude: self.currentLocation!.lat,
+                                                                     longitude: self.currentLocation!.lon)
+                                        self.encounterDistance = newLocation.distance(from: oldLocation)
+                                        self.pokemonEncounterId = nil
+                                        if self.listScatterPokemon {
+                                            self.listScatterPokemon = false
+                                            self.scatterPokemon = data?["scatter_pokemon"]
+                                                as? [[String: Any]] ?? [[String: Any]]()
+                                        }
+                                        self.waitForData = false
+                                        toPrint = "[DEBUG] Got Data and found Wild Pokemon"
+                                    } else {
+                                        toPrint = "[DEBUG] Got Data but didn't find Wild Pokemon"
+                                    }
+                                } else {
+                                    toPrint = "[DEBUG] Got Data without Wild Pokemon"
+                                }
                             }
-
                         } else if self.waitRequiresPokemon {
-                            if (nearby + wild) > 0 {
-                                toPrint = "[DEBUG] Got Data with Pokemon"
-                                self.waitForData = false
+                            if !self.config.wildsOnly {
+                                if (nearby + wild) > 0 {
+                                    toPrint = "[DEBUG] Got Data with Nearby And Wild Pokemon"
+                                    self.waitForData = false
+                                } else {
+                                    toPrint = "[DEBUG] Got Data without Nearby And Wild Pokemon"
+                                }
                             } else {
-                                toPrint = "[DEBUG] Got Data without Pokemon"
+                                if (wild) > 0 {
+                                    toPrint = "[DEBUG] Got Data with Wild Pokemon"
+                                    self.waitForData = false
+                                } else {
+                                    toPrint = "[DEBUG] Got Data without Wild Pokemon"
+                                }
                             }
                         } else {
                             toPrint = "[DEBUG] Got Data"
@@ -1202,7 +1237,11 @@ class RealDeviceMap_UIControlUITests: XCTestCase {
                         if let data = result!["data"] as? [String: Any], let action = data["action"] as? String {
                             self.action = action
                             if action == "scan_pokemon" {
-                                print("[STATUS] Pokemon")
+                                if self.config.wildsOnly {
+                                    print("[STATUS] WO Pokemon")
+                                } else {
+                                    print("[STATUS] Pokemon")
+                                }
                                 if self.hasWarning && self.config.enableAccountManager {
                                     Log.info("Account has a warning and tried to scan for Pokemon. Logging out!")
                                     self.lock.lock()


### PR DESCRIPTION
Easy Way To Make Sure A Worker Waits For Wild Pokemon Only.

## Description
Adds A Toggle To Prevent Workers From Moving To Their Next Loc On Nearby Pokemon Hits And Only Allows Wild Data Hits

## Motivation and Context
Useful For Wild Scanning Instances (Cheep And Easy Way To Do It)

## How Has This Been Tested?
Ran For Months On Several Community Days

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
