### PR TITLE
reworked startup, changed order of checks. Updated isStartup function…

### DIFF
--- a/RealDeviceMap-UIControl/Misc.swift
+++ b/RealDeviceMap-UIControl/Misc.swift
@@ -300,8 +300,7 @@ extension XCTestCase {
 
     }
 
-    func isStartup(click: Int = 0, screenshot: XCUIScreenshot?=nil) -> Bool {
-        let tapMe = click
+    func isStartup(click: Bool=false, screenshot: XCUIScreenshot?=nil) -> Bool {
         let screenshotComp = screenshot ?? XCUIScreen.main.screenshot()
 
         if screenshotComp.rgbAtLocation(
@@ -313,7 +312,7 @@ extension XCTestCase {
             min: (red: 0.28, green: 0.79, blue: 0.62),
             max: (red: 0.33, green: 0.85, blue: 0.68)
         ) {
-            if tapMe == 1 {
+            if click {
                 Log.startup("Clearing Caution Sign prompt")
                 deviceConfig.startupNewButton.toXCUICoordinate(app: app).tap()
             }
@@ -327,7 +326,7 @@ extension XCTestCase {
             min: (red: 0.15, green: 0.41, blue: 0.45),
             max: (red: 0.19, green: 0.46, blue: 0.49)
         ) {
-            if tapMe == 1 {
+            if click {
                 Log.startup("Clearing 2 line caution prompt")
                 deviceConfig.startupOldOkButton.toXCUICoordinate(app: app).tap()
             }
@@ -341,7 +340,7 @@ extension XCTestCase {
             min: (red: 0.99, green: 0.99, blue: 0.99),
             max: (red: 1.01, green: 1.01, blue: 1.01)
         ) {
-            if tapMe == 1 {
+            if click {
                 Log.startup("Clearing 3 line prompt")
                 deviceConfig.startupOldOkButton.toXCUICoordinate(app: app).tap()
             }
@@ -353,9 +352,9 @@ extension XCTestCase {
     /*
     // Planned detection for partially completed reloads, but doesn't seem worth it now :shrug:
     func failedTutorialMethod1(screenshot: XCUIScreenshot?=nil) -> Bool {
-        
+
         let screenshotComp = screenshot ?? getScreenshot()
-        
+
         if screenshotComp.rgbAtLocation(
             pos: deviceConfig.compareTutorialL,
             min: (red: 0.3, green: 0.5, blue: 0.6),
@@ -368,11 +367,11 @@ extension XCTestCase {
         } else {
             return false
         }
-        
+
     }
-    
+
     func failedTutorialMethod2(screenshot: XCUIScreenshot?=nil) -> Bool{
-    
+
         //let screenshotComp = screenshot ?? getScreenshot()
         /*
         if screenshotComp.rgbAtLocation(
@@ -383,13 +382,13 @@ extension XCTestCase {
         }
         */
         return true
-        
+
     }
-    
+
     func failedTutorialMethod3(screenshot: XCUIScreenshot?=nil) -> Bool{
-        
+
         //let screenshotComp = screenshot ?? getScreenshot()
-        
+
         /*if screenshotComp.rgbAtLocation(
             pos: deviceConfig.tutorialProfessorCheck,
             min: (red: 0.85, green: 0.9, blue: 0.00),
@@ -398,11 +397,11 @@ extension XCTestCase {
         }*/
         return true
     }
-    
+
     func failedTutorialMethod4(screenshot: XCUIScreenshot?=nil) -> Bool {
-        
+
         //let screenshotComp = screenshot ?? getScreenshot()
-        
+
         /*if screenshotComp.rgbAtLocation(
             pos: deviceConfig.tutorialProfessorCheck,
             min: (red: 0.85, green: 0.9, blue: 0.00),

--- a/RealDeviceMap-UIControl/Misc.swift
+++ b/RealDeviceMap-UIControl/Misc.swift
@@ -160,7 +160,7 @@ extension XCTestCase {
     }
 
     func checkHasWarning(screenshot: XCUIScreenshot?=nil) -> Bool {
-        Log.debug("Checking for the warning pop-up")
+        Log.debug("Checking for the red warning")
         let screenshotComp = screenshot ?? getScreenshot()
         if screenshotComp.rgbAtLocation(
             pos: deviceConfig.compareWarningL,
@@ -170,6 +170,7 @@ extension XCTestCase {
             pos: deviceConfig.compareWarningR,
             min: (red: 0.03, green: 0.07, blue: 0.10),
             max: (red: 0.07, green: 0.11, blue: 0.14)) {
+            Log.debug("Look like you have been warned...")
             return true
         } else {
             return false
@@ -299,8 +300,8 @@ extension XCTestCase {
 
     }
 
-    func isStartup(screenshot: XCUIScreenshot?=nil) -> Bool {
-
+    func isStartup(click: Int = 0, screenshot: XCUIScreenshot?=nil) -> Bool {
+        let tapMe = click
         let screenshotComp = screenshot ?? XCUIScreen.main.screenshot()
 
         if screenshotComp.rgbAtLocation(
@@ -312,8 +313,10 @@ extension XCTestCase {
             min: (red: 0.28, green: 0.79, blue: 0.62),
             max: (red: 0.33, green: 0.85, blue: 0.68)
         ) {
-            Log.startup("Should be clearing Caution Sign new startup prompt")
-            deviceConfig.startupNewButton.toXCUICoordinate(app: app).tap()
+            if tapMe == 1 {
+                Log.startup("Clearing Caution Sign prompt")
+                deviceConfig.startupNewButton.toXCUICoordinate(app: app).tap()
+            }
             return true
         } else if screenshotComp.rgbAtLocation(
             pos: deviceConfig.startupOldOkButton,
@@ -324,8 +327,10 @@ extension XCTestCase {
             min: (red: 0.15, green: 0.41, blue: 0.45),
             max: (red: 0.19, green: 0.46, blue: 0.49)
         ) {
-            Log.startup("Should be Clearing the 2 line long, old style startup prompt")
-            deviceConfig.startupOldOkButton.toXCUICoordinate(app: app).tap()
+            if tapMe == 1 {
+                Log.startup("Clearing 2 line caution prompt")
+                deviceConfig.startupOldOkButton.toXCUICoordinate(app: app).tap()
+            }
             return true
         } else if screenshotComp.rgbAtLocation(
             pos: deviceConfig.startupOldOkButton,
@@ -336,8 +341,10 @@ extension XCTestCase {
             min: (red: 0.99, green: 0.99, blue: 0.99),
             max: (red: 1.01, green: 1.01, blue: 1.01)
         ) {
-            Log.startup("Should be clearing the 3 line long, old school style prompt")
-            deviceConfig.startupOldOkButton.toXCUICoordinate(app: app).tap()
+            if tapMe == 1 {
+                Log.startup("Clearing 3 line prompt")
+                deviceConfig.startupOldOkButton.toXCUICoordinate(app: app).tap()
+            }
             return true
         }
 

--- a/RealDeviceMap-UIControl/RealDeviceMap_UIControlUITests.swift
+++ b/RealDeviceMap-UIControl/RealDeviceMap_UIControlUITests.swift
@@ -345,7 +345,7 @@ class RealDeviceMap_UIControlUITests: XCTestCase {
                     min: (0.15, 0.33, 0.17),
                     max: (0.25, 0.43, 0.27)) {
                     Log.debug("App is in age verification.")
-                    
+
                     print("[STATUS] Age verification")
                     //Open the year select
                     deviceConfig.ageVerificationYear.toXCUICoordinate(app: app).tap()
@@ -362,7 +362,7 @@ class RealDeviceMap_UIControlUITests: XCTestCase {
                     //Submit
                     deviceConfig.ageVerification.toXCUICoordinate(app: app).tap()
                     sleep(1 * config.delayMultiplier)
-                
+
                     sleep(1 * config.delayMultiplier)
                     deviceConfig.loginNewPlayer.toXCUICoordinate(app: app).tap()
                     sleep(1 * config.delayMultiplier)
@@ -1056,7 +1056,7 @@ class RealDeviceMap_UIControlUITests: XCTestCase {
                 if !isStartupCompleted {
                     Log.debug("Performing Startup sequence")
                     currentLocation = config.startupLocation
-                    
+
                     sleep(1 * config.delayMultiplier)
                     hasWarning = self.checkHasWarning()
                     if hasWarning {  //<-- rw happens before news on startup
@@ -1866,7 +1866,7 @@ class RealDeviceMap_UIControlUITests: XCTestCase {
                 }
             }
         }
-        
+
     }
 
     func zoom(out: Bool, app: XCUIApplication, coordStartup: XCUICoordinate) {

--- a/RealDeviceMap-UIControl/RealDeviceMap_UIControlUITests.swift
+++ b/RealDeviceMap-UIControl/RealDeviceMap_UIControlUITests.swift
@@ -363,13 +363,12 @@ class RealDeviceMap_UIControlUITests: XCTestCase {
                     deviceConfig.ageVerification.toXCUICoordinate(app: app).tap()
                     sleep(1 * config.delayMultiplier)
                 
-                
                     sleep(1 * config.delayMultiplier)
                     deviceConfig.loginNewPlayer.toXCUICoordinate(app: app).tap()
                     sleep(1 * config.delayMultiplier)
                     deviceConfig.loginPTC.toXCUICoordinate(app: app).tap()
                 }
-               
+
                 if screenshotComp.rgbAtLocation(
                     pos: self.deviceConfig.startupLoggedOut,
                     min: (0.95, 0.75, 0.0),
@@ -420,7 +419,6 @@ class RealDeviceMap_UIControlUITests: XCTestCase {
                 sleep(1 * config.delayMultiplier)
             }
 
-            
         }
     }
 
@@ -1058,7 +1056,6 @@ class RealDeviceMap_UIControlUITests: XCTestCase {
                 if !isStartupCompleted {
                     Log.debug("Performing Startup sequence")
                     currentLocation = config.startupLocation
-
                     
                     sleep(1 * config.delayMultiplier)
                     hasWarning = self.checkHasWarning()
@@ -1854,7 +1851,7 @@ class RealDeviceMap_UIControlUITests: XCTestCase {
                     sleep(2 * config.delayMultiplier)
                     shouldExit = true
                     return
-                } else if isStartup(click: 1) { //<-- caution sign must be present here to complete startup
+                } else if isStartup(click: true) { //<-- caution sign must be present here to complete startup
                     Log.info("App Started")
                     isStarted = true  // <-- only place isStarted set to true
                     sleep(1 * config.delayMultiplier)
@@ -1869,7 +1866,7 @@ class RealDeviceMap_UIControlUITests: XCTestCase {
                 }
             }
         }
-
+        
     }
 
     func zoom(out: Bool, app: XCUIApplication, coordStartup: XCUICoordinate) {


### PR DESCRIPTION
Changed isStartup in misc.swift. The caution prompts are needed to complete startup in part8main, isStartup will return true, but not click caution until part8. Moved rw detection above closeNews (closeNews was actually clearing rw before rw check, why it never worked). Removed the check for account manager in part1setup so the failed login and tos checks can run there and not create 42 checks in logs. 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
changes made to misc.swift. added a variable with default value of 0. only clicks warning sign when value is 1. 
Realdevicemap_uicontroltests.swift - removed check for account manager in part1setup.
Moved screen check for age verification and login to first 2 checks. Next check is failed login. then tos check. Added a delay between these checks so they do not run more than necessary.
Moved closeNews to click after check for rw, closeNews has been blindly closing rw and thats why rw detection has never worked.
isStartup will not close the caution prompt until part8main. It is the only thing that sets isStarted to true in the entire program (part8main). Removed all tos checks from inside part8main because those checks will never exist there (tos comes before caution, can't get to caution without clearing tos, can't get inside code block where tos checks were without clearing caution sign)
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
see above
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
with devices
<!--- Include details of your testing environment, and the tests you ran to -->
a dark cold room with dim lights and glowing eyes. Mac OS, iPhone se.
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.