### PR TITLE
add disable/enable toggle for device to main menu

### DIFF
--- a/Manager/Sources/RDMUICManager/CLI.swift
+++ b/Manager/Sources/RDMUICManager/CLI.swift
@@ -74,12 +74,13 @@ class CLI {
         4. Add Device
         5. Edit Device
         6. Delete Device
+        7. Toggle Device
         0. Exit
         ================
         """
 
         print(menu)
-        let number = askInput("Please select an option", options: [0, 1, 2, 3, 4, 5, 6])
+        let number = askInput("Please select an option", options: [0, 1, 2, 3, 4, 5, 6, 7])
         print()
         switch number {
         case 1:
@@ -99,6 +100,9 @@ class CLI {
             return true
         case 6:
             deleteDevice()
+            return true
+        case 7:
+            toggleDevice()
             return true
         default:
             return false
@@ -717,6 +721,44 @@ class CLI {
             print("Device deleted.\n\n")
         } catch {
             print("Failed to delete device.\n\n")
+        }
+    }
+
+    private func toggleDevice() {
+        clear()
+        let devices = Device.getAll()
+        print("=======================")
+        print("Select Device to Toggle")
+        print("=======================")
+        var i = 1
+        for device in devices {
+            print("\(i): \(device.name)")
+            i += 1
+        }
+        print("0: Back")
+        print("=====================")
+        let index = askInput("Please select an option", options: Array(0...devices.count))
+        print()
+        if index == 0 {
+            clear()
+            return
+        }
+        let device = devices[index - 1]
+        device.enabled = 1 - device.enabled
+
+        do {
+            try device.save()
+            clear()
+            BuildController.global.removeDevice(device: device)
+            let tmpQueue = Threading.getQueue(name: UUID().uuidString, type: .serial)
+            tmpQueue.dispatch {
+                Threading.sleep(seconds: 10.0)
+                BuildController.global.addDevice(device: device)
+                Threading.destroyQueue(tmpQueue)
+            }
+            print("Device toggled.\n\n")
+        } catch {
+            print("Failed to toggle device.\n\n")
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added quick option to toggle device between enabled/disabled

## Description
Quickly toggle device between enabled/disabled using dedicated main menu option without having to go through all device options.

## Motivation and Context
Ease of use when disabled/enabling device

## How Has This Been Tested?
Tested on my system

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
