### PR TITLE
Fixes login and manual questing using GD on 0.171.1

### DIFF
--- a/RealDeviceMap-UIControl/DeviceConfig/DeviceRatio1775.swift
+++ b/RealDeviceMap-UIControl/DeviceConfig/DeviceRatio1775.swift
@@ -184,16 +184,16 @@ class DeviceRatio1775: DeviceConfigProtocol {
         return DeviceCoordinate(x: 590, y: 970, scaler: scaler)
     }
     var questDelete: DeviceCoordinate {
-        return DeviceCoordinate(x: 598, y: 530, scaler: scaler)
+        return DeviceCoordinate(x: 596, y: 570, scaler: scaler)
     }
     var questFilledColor1: DeviceCoordinate {
-        return DeviceCoordinate(x: 46, y: 527, scaler: scaler)
+        return DeviceCoordinate(x: 44, y: 567, scaler: scaler)
     }
     var questDeleteWithStack: DeviceCoordinate {
-        return DeviceCoordinate(x: 600, y: 700, scaler: scaler)
+        return DeviceCoordinate(x: 596, y: 739, scaler: scaler)
     }
     var questFilledColorWithStack1: DeviceCoordinate {
-        return DeviceCoordinate(x: 46, y: 693, scaler: scaler)
+        return DeviceCoordinate(x: 44, y: 736, scaler: scaler)
     }
     var questDeleteConfirm: DeviceCoordinate {
         return DeviceCoordinate(x: 320, y: 620, scaler: scaler)
@@ -242,7 +242,7 @@ class DeviceRatio1775: DeviceConfigProtocol {
     }
 
     var loginPTC: DeviceCoordinate {
-        return DeviceCoordinate(x: 320, y: 800, scaler: scaler)
+        return DeviceCoordinate(x: 320, y: 700, scaler: scaler)
     }
 
     var loginUsernameTextfield: DeviceCoordinate {

--- a/RealDeviceMap-UIControl/Misc.swift
+++ b/RealDeviceMap-UIControl/Misc.swift
@@ -1049,6 +1049,12 @@ extension XCTestCase {
         let start = Date()
         deviceConfig.openQuest.toXCUICoordinate(app: app).tap()
         sleep(1 * config.delayMultiplier)
+        //get us to a known location by swiping left twice (placing us on the special research tab)
+        app.swipeLeft()
+        sleep(1 * config.delayMultiplier)
+        app.swipeLeft()
+        sleep(1 * config.delayMultiplier)
+        //now we can swipe right once to get us to the field research (quests) tab
         app.swipeRight()
         sleep(1 * config.delayMultiplier)
 


### PR DESCRIPTION
## Description
Contains pixel updates for the PTC login button as well as the delete buttons for clearing out quests manually (for non-GDS users).  Also added additional swipe logic to ensure we always land on the quests screen.  This is to account for the addition of the "Today" screen.

## Motivation and Context
These changes allow UIControl to continue functioning properly with the UI changes introduced in 0.171.1

## How Has This Been Tested?
These changes have been tested in my live environment for the past several nights using iPhone SE devices and GD.  I have verified that accounts are able to successfully login and that quests are properly deleted (allowing quest scanning to fully complete).

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
